### PR TITLE
Fix incorrect links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ embedding that instead:
 
 The code for this is hosted on [labl.es](https://labl.es).
 
-It works just like similar badge generator sites like [shields.io](shields.io) or [badge.fury.io](badge.fury.io)
+It works just like similar badge generator sites like [shields.io](https://shields.io/) or [badge.fury.io](https://badge.fury.io/)
 
 
 ### What's included


### PR DESCRIPTION
Currently you are redirected to `https://github.com/bhousel/svg-labels/blob/master/shields.io`, instead of `shields.io`